### PR TITLE
Enable use of FontAwesome for icons

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.1/css/all.css" crossorigin="anonymous">

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,10 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.1/css/all.css" crossorigin="anonymous">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/Components/Icon/index.js
+++ b/src/Components/Icon/index.js
@@ -12,7 +12,7 @@ function Icon(props) {
   }
 
   return (
-    <div>IconNotFound</div>
+    <i class={`fa fa-${name}`} style={{fontSize: size + 'px'}} />
   );
 }
 

--- a/src/stories/Icon.stories.js
+++ b/src/stories/Icon.stories.js
@@ -6,4 +6,4 @@ export default {
   component: Icon,
 };
 
-export const presentation = () => <Icon name="bananaIcon" size={100} />;
+export const presentation = () => <Icon name="user" size={100} />;


### PR DESCRIPTION

#### Please check if the PR fulfills these requirements

- [x] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Enables the use of FontAwesome icons in the Icon component (https://fontawesome.com/v4.7.0/icons/).


#### What is the current behavior? (You can also link to an open issue here)
Icon names that aren't found in the mapping returns text reading "Icon not found."


#### What is the new behavior? (if this is a feature change)
Unmapped icon text defaults to pulling an icon name from the FontAwesome free icon collection.  The size prop sets the size of the icon in px.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)



#### Other information
Note that this does not correspond to any outstanding Trello cards; however, I felt this was an important change to make for greater flexibility in the use of icons going forward here. 
There is no mechanism at this point to use anything other than the basic icons.


#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)


---


#### TODO
