### PR TITLE
Add custom css height and width props to ProfilePicture component

### DIFF
--- a/src/Components/ProfilePicture/index.js
+++ b/src/Components/ProfilePicture/index.js
@@ -5,14 +5,19 @@ import styles from './style.module.css';
 const classNames = require('classnames');
 
 function ProfilePicture(props) {
-  const { blueBorder, srcImage } = props;
+  const {
+    blueBorder,
+    srcImage,
+    customHeight,
+    customWidth,
+  } = props;
   const profPic = classNames({
     [styles.profPic]: true,
     [styles.blueBorder]: blueBorder,
   });
   return (
     <div className={styles.imgDiv}>
-      {srcImage !== '#' && (<img src={srcImage} className={profPic} alt="" />)}
+      {srcImage !== '#' && (<img src={srcImage} style={{ height: customHeight, width: customWidth }} className={profPic} alt="" />)}
     </div>
   );
 }
@@ -20,11 +25,15 @@ function ProfilePicture(props) {
 ProfilePicture.propTypes = {
   blueBorder: PropTypes.bool,
   srcImage: PropTypes.string,
+  customHeight: PropTypes.number,
+  customWidth: PropTypes.number,
 };
 
 ProfilePicture.defaultProps = {
   blueBorder: true,
   srcImage: '#',
+  customHeight: 150, /* Height of container on Profile Page */
+  customWidth: 150, /* Width of container on Profile Page */
 };
 
 export default ProfilePicture;

--- a/src/Components/ProfilePicture/index.js
+++ b/src/Components/ProfilePicture/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './style.module.css';
+import BANANA from '../../Image/BANANA.svg';
 
 const classNames = require('classnames');
 
@@ -17,7 +18,7 @@ function ProfilePicture(props) {
   });
   return (
     <div className={styles.imgDiv}>
-      {srcImage !== '#' && (<img src={srcImage} style={{ height: customHeight, width: customWidth }} className={profPic} alt="" />)}
+      {srcImage && (<img src={srcImage} style={{ height: customHeight, width: customWidth }} className={profPic} alt="" />)}
     </div>
   );
 }
@@ -31,7 +32,7 @@ ProfilePicture.propTypes = {
 
 ProfilePicture.defaultProps = {
   blueBorder: true,
-  srcImage: '#',
+  srcImage: BANANA,
   customHeight: 150, /* Height of container on Profile Page */
   customWidth: 150, /* Width of container on Profile Page */
 };

--- a/src/Components/ProfilePicture/style.module.css
+++ b/src/Components/ProfilePicture/style.module.css
@@ -1,7 +1,5 @@
 .profPic {
     border-radius: 50%;
-    width: 150px; /* width of container */
-    height: 150px; /* height of container */
     object-fit: cover;
     
 }


### PR DESCRIPTION
Add props to ProfilePicture component that allow you pass in a custom height and width

## Pull Request Template

#### Please check if the PR fulfills these requirements

- [ x ] The changes don't come from your master branch. ([Source](https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)) 

---

### [Trello Card](https://trello.com/c/Kr2IgUGx)

#### What kind of change does this PR introduce? (bug fix, feature, docs update, ...)
This PR adds two props to the ProfilePicture component (customHeight, customWidth). These two props are type number and expect to receive a number in pixels to which you want the height and width set. The default for both is set to 150px. 

Please delete options that are not relevant.

- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] This change requires a documentation update


#### What is the current behavior? (You can also link to an open issue here)
The height and width of the ProfilePicture component are hard coded to 150px.


#### What is the new behavior? (if this is a feature change)
The default height and width are 150px, but now you can pass in a custom height and width to fit new layouts.


#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


#### Other information



#### Discussion Questions



#### Images (before/ after screenshots, interaction GIFs, ...)



#### Please test your work using the [Accessibility Insights for Web](https://chrome.google.com/webstore/detail/accessibility-insights-fo/pbjjkligggfmakdaogkfomddhfmpjeni) plugin. Include any relevant notes and screenshots.


---


#### TODO:
- this
- that
- other

